### PR TITLE
Fix/modal styling

### DIFF
--- a/src/Components/Modal/Modal.css
+++ b/src/Components/Modal/Modal.css
@@ -34,11 +34,13 @@
 }
 
 .header-text {
-  margin-left: 10px;
+  margin-left: 20px;
 }
 
 .modal-image {
-  width: 70%;
+  min-width: 55%;
+  max-width: 70%;
+  max-height: 80%;
   border-radius: 5px;
   margin-bottom: 20px;
 }

--- a/src/Components/Modal/Modal.css
+++ b/src/Components/Modal/Modal.css
@@ -22,7 +22,7 @@
   min-height: 500px;
   background: white;
   border: 2px solid rgb(83, 83, 83);
-  border-radius: 5px;
+  border-radius: 8px;
   display: flex;
   flex-direction: column;
   transition: all .4s ease-in-out;

--- a/src/Components/Modal/Modal.js
+++ b/src/Components/Modal/Modal.js
@@ -10,9 +10,7 @@ const Modal = ({ open, picture, description, sell, updateModal , articleID, logg
 
   const closeModalHandler = (event) => {
     if(event.target.className.includes('close-able')) {
-      setTimeout(() => {
         updateModal(false)
-      }, 400);
     }
   };
 


### PR DESCRIPTION
Fixes bug where tall images push modal size to extend off the window's view.
Removes setTimeout on modal close, since animations weren't implemented.
Updated border-radius on modal and margin for header text

## What does this merge do? Check all that apply.
- [X] Improves an existing feature
- [X] Fixes a bug

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have used tests to prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my change
